### PR TITLE
fix: Request oldPassword if password is provided

### DIFF
--- a/src/app/controllers/UserController.js
+++ b/src/app/controllers/UserController.js
@@ -52,7 +52,7 @@ class UserController {
       return res.status(400).json({ error: 'Validation fails' });
     }
 
-    const { email, oldPassword } = req.body;
+    const { email, password, oldPassword } = req.body;
 
     const user = await User.findByPk(req.userId);
 
@@ -66,6 +66,10 @@ class UserController {
 
     if (oldPassword && !(await user.checkPassword(oldPassword))) {
       return res.status(401).json({ error: 'Password does not match' });
+    }
+
+    if (password && !oldPassword) {
+      return res.status(401).json({ error: 'Old password not provided' });
     }
 
     const { id, name, provider } = await user.update(req.body);


### PR DESCRIPTION
Se o update do usuário fosse feito sem o campo `oldPassword`, ele passaria a verificação e alteraria a senha sem fazer a comparação com a senha antiga.

Exemplo:

```
{
  "name": "John Doe",
  "email": "johndoe@gmail.com",
  "password": "12345678",
  "confirmPassword": "12345678"
}
```

A verificação adicionada garante que o usuário forneça a senha alterior para fazer a alteração.